### PR TITLE
Fix #18 Child module org.eclipse.ec4j does not exist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,6 @@
 	<version>0.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
-        <module>org.eclipse.ec4j</module>
 		<module>org.eclipse.ec4e</module>
 		<module>org.eclipse.ec4e.repository</module>
 	</modules>


### PR DESCRIPTION
This fixes only the problem reported in #18 . 

I also tried to persuade tycho to pull org.eclipse.ec4j 0.0.1-SNAPSHOT from the local maven repo but I have not succeeded in a reasonable time. Maybe @mickaelistria knows how to do that?
